### PR TITLE
Dockerfile refresh 2021

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: "docker"
+  directory: "/base"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 10
+

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --user -r requirements-pinned.txt
 RUN pip install --user in-toto
 
 FROM alpine:3.14 AS built-image
-LABEL maintainer="Santiago Torres Arias <santiago@nyu.edu>"
+LABEL maintainer="Santiago Torres Arias <santiagotorres@purdue.edu>"
 
 RUN apk update && apk add python3
 COPY --from=base-image /root/.local /root/.local

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,11 +1,20 @@
-FROM alpine:3.8
+FROM alpine:3.14 as base-image
+
+RUN apk update && apk add python3 python3-dev py3-pip build-base py3-cffi libressl-dev libffi-dev
+RUN pip install --upgrade pip && pip install wheel
+WORKDIR /root
+# install latest pinned requirements available from in-toto repo
+# by doing this via '--user' we keep all libs/wheels in ~/.local
+# which can be easily copied into our second stage of the image build
+RUN wget https://github.com/in-toto/in-toto/raw/develop/requirements-pinned.txt
+RUN pip install --user -r requirements-pinned.txt
+RUN pip install --user in-toto
+
+FROM alpine:3.14 AS built-image
 LABEL maintainer="Santiago Torres Arias <santiago@nyu.edu>"
 
-RUN apk update && apk add python2 python2-dev py2-pip build-base py2-cffi libressl-dev
-
-# FIXME: colorama shouldn't be there, but the upstream dependency is broken
-# until the next release.
-RUN pip install in-toto colorama
-
+RUN apk update && apk add python3
+COPY --from=base-image /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
 RUN mkdir /workspace
 WORKDIR /workspace


### PR DESCRIPTION
The base/Dockerfile has been refactored to use a multi-stage build as [suggested](https://github.com/in-toto/Dockerfiles/issues/1) by @SantiagoTorres. This has cut the size of the image (approximately) in half down to 73.3 MB.

I have also updated the alpine image to the latest stable version available (3.14). In order to automate this in the future, I have also included a GitHub Dependabot config that will scan the /base directory on a weekly basis looking for updates to alpine's image used within this Dockerfile for building and packaging the final container image.