### PR TITLE
Fix issue with dependencies not being installed to ~/.local

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,8 +6,13 @@ WORKDIR /root
 # install latest pinned requirements available from in-toto repo
 # by doing this via '--user' we keep all libs/wheels in ~/.local
 # which can be easily copied into our second stage of the image build
+# we use the --force-reinstall flag because some dependencies like six
+# are installed at the system level by apk, and are not by default
+# installed to ~/.local
+# py3-pip, for example, requires py3-six
+# https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-pip
 RUN wget https://github.com/in-toto/in-toto/raw/develop/requirements-pinned.txt
-RUN pip install --user -r requirements-pinned.txt
+RUN pip install --user --force-reinstall -r requirements-pinned.txt
 RUN pip install --user in-toto
 
 FROM alpine:3.14 AS built-image


### PR DESCRIPTION
`six` is not installed to `~/.local` because by default, the requirement is fulfilled by the copy in `/usr/lib/...`. This patch adds the `--force-reinstall` flag to ignore that copy.

py3-pip requires py3-six, and so apk installs it system-wide: https://pkgs.alpinelinux.org/package/edge/community/x86_64/py3-pip